### PR TITLE
Add reasoning_effort param for GPT-5 model

### DIFF
--- a/trainers/compatibility_adapter.py
+++ b/trainers/compatibility_adapter.py
@@ -91,6 +91,7 @@ class CompatibilityAdapter(GEPAAdapter[ATLASDataInst, ATLASTrajectory, ATLASRoll
 
         if 'gpt-5' in model.lower() or 'o1' in model.lower():
             completion_params['max_completion_tokens'] = self.generation_config.get('max_tokens', 2048)
+            completion_params['reasoning_effort'] = self.generation_config.get('reasoning_effort', 'medium')
         else:
             completion_params['max_tokens'] = self.generation_config.get('max_tokens', 2048)
             completion_params['temperature'] = self.generation_config.get('temperature', 0.7)

--- a/trainers/configurable_evaluator.py
+++ b/trainers/configurable_evaluator.py
@@ -164,12 +164,19 @@ IMPORTANT:
         try:
             import litellm
 
-            llm_response = litellm.completion(
-                model=self.evaluation_model,
-                messages=[{"role": "user", "content": eval_prompt}],
-                temperature=0.1,
-                max_tokens=500
-            )
+            completion_params = {
+                'model': self.evaluation_model,
+                'messages': [{"role": "user", "content": eval_prompt}],
+            }
+
+            if 'gpt-5' in self.evaluation_model.lower() or 'o1' in self.evaluation_model.lower():
+                completion_params['max_completion_tokens'] = 500
+                completion_params['reasoning_effort'] = 'low'
+            else:
+                completion_params['temperature'] = 0.1
+                completion_params['max_tokens'] = 500
+
+            llm_response = litellm.completion(**completion_params)
 
             response_text = llm_response.choices[0].message.content.strip()
             evaluation_result = self._parse_llm_evaluation(response_text)


### PR DESCRIPTION
Introduces the 'reasoning_effort' parameter to completion calls for GPT-5 models in compatibility_adapter, configurable_evaluator, and prompt_adapter. This allows finer control over model reasoning behavior, aligning with updated API requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for GPT-5 and O1-family models with a new reasoning effort control (default: medium) and improved token limits for both single and batch completions.
  * Adaptive parameter selection per model to improve response quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->