### PR TITLE
fix: resolve API Docs Reference 404 error

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "API Reference",
-      "url": "/api-reference"
+      "url": "/api-reference/configs"
     }
   ],
   "navigation": [


### PR DESCRIPTION
This pull request makes a small update to the documentation navigation by changing the URL for the "API Reference" section to point to the `/api-reference/configs` path instead of `/api-reference`.