### PR TITLE
Expand reward config docs and clarify judge specs

### DIFF
--- a/docs/api-reference/configs.mdx
+++ b/docs/api-reference/configs.mdx
@@ -181,14 +181,32 @@ The reward ensemble is configured through Hydra rather than direct constructor a
 rim:
   temperatures: [0.2, 0.5, 0.8]
   variance_threshold: 0.15
+  models:
+    small_model: "gemini/gemini-2.5-flash"
+    large_model: "gemini/gemini-2.5-pro"
   active_judges:
     accuracy: true
     helpfulness: true
     process: true
     diagnostic: true
+  model_configs:
+    default:
+      max_tokens: 32768
+      response_format: "json"
+    large:
+      max_tokens: 32768
+      response_format: "json"
+  consistency_rules:
+    alignment_completeness_bound: 0.1
+    completeness_helpfulness_threshold: 0.5
+    understanding_helpfulness_bound: 0.1
+    contradiction_penalty: 0.2
+    safety_violation_penalty: 0.2
   anti_gaming:
     enabled: true
     cap_score: 0.3
+  parallel_execution:
+    max_workers: 8
 ```
 
 Lower temperatures concentrate the judges around deterministic reasoning, while higher values encourage diverse principle discovery. The variance threshold controls escalation sensitivity: smaller numbers escalate more often, improving correctness at the cost of latency. Disabling a judge removes that dimension from the combined score but still records explanations for active ones. Anti-gaming caps anomalous scores when judges detect contradictions or safety violations.

--- a/docs/concepts/reward-design.mdx
+++ b/docs/concepts/reward-design.mdx
@@ -19,7 +19,7 @@ The reward system's evaluation process is a multi-step workflow designed to bala
   </Step>
 
   <Step title="2. Principle-Guided Rationale">
-    A core feature of the system is its explainability. Judges are required by their prompts (defined in `RIM/judges.py`) to provide a structured rationale for their scores. For instance, the `AccuracyJudge` must first generate and weigh a set of evaluation principles, making its final score fully auditable, while other judges like `HelpfulnessJudge` return different structured outputs like an `evidence` list.
+    A core feature of the system is its explainability. Judges are required by their prompts (defined in `RIM/judge_specs.py`) to provide a structured rationale for their scores. For instance, the `AccuracyJudge` must first generate and weigh a set of evaluation principles, making its final score fully auditable, while other judges like `HelpfulnessJudge` return different structured outputs like an `evidence` list.
   </Step>
 
   <Step title="3. Uncertainty & Disagreement Check">
@@ -70,11 +70,31 @@ rim:
     process: true
     diagnostic: true
 
+  model_configs:
+    default:
+      max_tokens: 32768
+      response_format: "json"
+    large:
+      max_tokens: 32768
+      response_format: "json"
+
+  consistency_rules:
+    alignment_completeness_bound: 0.1
+    completeness_helpfulness_threshold: 0.5
+    understanding_helpfulness_bound: 0.1
+    contradiction_penalty: 0.2
+    safety_violation_penalty: 0.2
+
+  anti_gaming:
+    enabled: true
+    cap_score: 0.3
+
   # Configure parallel execution for the ensemble
   parallel_execution:
     max_workers: 8
 ```
 For different use cases, such as offline training where only process and helpfulness matter, you can create or use an alternative configuration file (e.g., `rim_offline_config.yaml`) that sets the `accuracy` and `diagnostic` flags to `false`.
+`model_configs` lets you tune per-model generation settings without editing code, while the `consistency_rules` block enforces the score relationships we rely on (for example, process cannot exceed accuracy by more than 0.1). The `anti_gaming` guard caps outlier scores when contradictions or safety issues are detected.
 
 ## Using the Reward System in Code
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -189,6 +189,15 @@ Run optimization:
 ./scripts/openai_agent_atlas.sh configs/wrappers/your_agent.yaml
 ```
 
+<Info>
+**Data sources:** The optimization script can fetch evaluation scenarios from more than just JSONL files. Set `data_source.type` in your YAML to choose one of the built-in loaders:
+- `file` — local JSONL on disk (default).
+- `http_api` — call a REST endpoint; optional transform directives remap the payload to `question` / `ground_truth` fields.
+- `prometheus_alerts` — pull active alerts from a Prometheus server.
+- `itbench_scenarios` — load ITBench incident specs and associated ground truths.
+- `custom_function` — point to any Python module and function that returns example dictionaries.
+</Info>
+
 ### Production Considerations
 
 - **Configuration-based**: All integrations use YAML configs for easy deployment


### PR DESCRIPTION
Added detailed configuration options for models, model generation settings, consistency rules, anti-gaming, and parallel execution in the reward ensemble documentation. Updated references to judge prompt definitions from `RIM/judges.py` to `RIM/judge_specs.py` for accuracy. Quickstart now explains supported data sources for evaluation scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded RIM configuration docs with model selection, per-model configs (e.g., max tokens, response format), detailed consistency rules, penalties, and parallel execution settings.
  - Added anti-gaming controls and clarified new guardrails in reward design guidance.
  - Updated references to the latest judge specification.
  - Enhanced Quickstart with a Data sources section covering built-in loaders (file, HTTP API, Prometheus alerts, benchmarks, custom functions) and default behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->