### PR TITLE
Add Atlas SDK runtime documentation

### DIFF
--- a/configs/examples/sdk_quickstart.yaml
+++ b/configs/examples/sdk_quickstart.yaml
@@ -1,0 +1,100 @@
+agent:
+  type: openai
+  name: sdk-quickstart-openai
+  system_prompt: |
+    You are the Atlas Student. Follow the task instructions carefully and keep responses concise unless asked to elaborate.
+  tools: []
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.0
+    max_output_tokens: 768
+  response_format: null
+
+student:
+  prompts:
+    planner: |
+      {base_prompt}
+
+      Break the user's task into a short numbered plan. Return a JSON object shaped exactly as {"steps": [...]} with each step containing id, description, and depends_on.
+    executor: |
+      {base_prompt}
+
+      Execute the current plan step. Show the work that led to your answer.
+    synthesizer: |
+      {base_prompt}
+
+      Summarize the important findings from every step and deliver the final answer.
+  max_plan_tokens: 1024
+  max_step_tokens: 1024
+  max_synthesis_tokens: 1024
+  tool_choice: auto
+
+teacher:
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.1
+    max_output_tokens: 768
+  max_review_tokens: 1024
+  plan_cache_seconds: 300
+  guidance_max_tokens: 256
+  validation_max_tokens: 256
+  prompts:
+    plan_review: |
+      {base_prompt}
+
+      You are reviewing the student's proposed plan. Ensure it keeps the original task goal. Respond with a JSON object containing a top-level "steps" array. Do not wrap the plan in any additional keys.
+  prompts:
+    plan_review: |
+      {base_prompt}
+
+      You are reviewing the student's proposed plan. Ensure it keeps the original task goal. Respond with a JSON object containing a top-level "steps" array. Do not wrap the plan in any additional keys.
+
+orchestration:
+  max_retries: 1
+  step_timeout_seconds: 600
+  rim_guidance_tag: rim_feedback
+  emit_intermediate_steps: true
+
+rim:
+  judges:
+    - identifier: process
+      kind: process
+      weight: 0.6
+      principles:
+        - Follows user instructions
+      llm:
+        provider: openai
+        model: gpt-4o-mini
+        api_key_env: OPENAI_API_KEY
+        temperature: 0.0
+        max_output_tokens: 512
+    - identifier: helpfulness
+      kind: helpfulness
+      weight: 0.4
+      principles:
+        - Provides useful answers
+      llm:
+        provider: openai
+        model: gpt-4o-mini
+        api_key_env: OPENAI_API_KEY
+        temperature: 0.0
+        max_output_tokens: 512
+  temperatures: [0.0, 0.3]
+  variance_threshold: 0.15
+  uncertainty_threshold: 0.3
+  arbiter:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.1
+    max_output_tokens: 512
+  success_threshold: 0.7
+  retry_threshold: 0.6
+  aggregation_strategy: weighted_mean
+
+storage: null
+prompt_rewrite: null

--- a/docs/architecture/system-overview.mdx
+++ b/docs/architecture/system-overview.mdx
@@ -11,7 +11,7 @@ ATLAS is an architecture for production teams that need AI agents to improve fro
 
 The core components are:
 1.  **[Reasoning Core](/concepts/teacher-student-paradigm)**: A Teacher-Student model pair that enhances agent capabilities.
-2.  **[Reward System (RIM)](/concepts/reward-design)**: Turns implicit and explicit user feedback into a dense reward signal.
+2.  **[Reward System](/concepts/reward-design)**: Turns implicit and explicit user feedback into a dense reward signal.
 3.  **[Learning Engine](/concepts/hybrid-learning)**: Uses online (GEPA) and offline (GRPO) methods to update models based on rewards.
 4.  **Persistent Memory**: Stores all interactions for analysis and retraining. This layer is configurable to use local disk, a cloud bucket (e.g., S3), or a production database (e.g., Postgres) for storage.
 
@@ -25,8 +25,42 @@ These components form the complete learning loop shown below. The system capture
 The architecture operates as a continuous cycle:
 
 1.  **Capture & Persist**: All agent interactions and user feedback (reward signals like edits, approvals, tool usage) are captured by the agent framework and stored in Persistent Memory.
-2.  **Score & Reward**: The Reward System (RIM) processes these raw signals, converting them into structured, dense rewards that quantify performance.
+2.  **Score & Reward**: The Reward System processes these raw signals, converting them into structured, dense rewards that quantify performance.
 3.  **Adapt & Learn**: The Learning Engine uses these rewards to update the Reasoning Core. Online adaptation (GEPA) handles rapid, task-specific tuning, while offline training (GRPO) builds deep, foundational skills.
 4.  **Redeploy**: The improved teacher model (or its updated policy) is redeployed to the Reasoning Core, enhancing the agent's performance on subsequent tasks.
 
 This entire loop is designed to be automated and run in production, enabling agents to compound intelligence over time.
+
+## SDK Runtime vs. Training Architecture
+
+The Atlas SDK provides the entry point to this learning loop. It is responsible for the **live execution** of tasks, while the broader Atlas training system handles the **offline improvement** of the models. The two systems are complementary.
+
+```mermaid
+graph TD
+    subgraph "SDK Runtime (Live Execution)"
+        A[Task Request] --> B(atlas.run);
+        B --> C{Student-Teacher Loop};
+        C -- Plan, Execute, Review --> C;
+        C --> D[Final Answer];
+        C --> E((Traces));
+    end
+
+    subgraph "Training System (Offline Improvement)"
+        F((Persistent Memory)) --> G[Learning Engine];
+        G -- GRPO / GEPA --> H[Model Update];
+        H --> I(Updated Teacher Model);
+    end
+
+    E --> F;
+    I --> C;
+
+    style B fill:#cde4ff
+    style G fill:#d2ffd2
+```
+
+1.  The **SDK Runtime** orchestrates your agent through a task. This process generates a `Final Answer` for the user and, crucially, detailed `Traces` of the interaction.
+2.  These **Traces are persisted** and become the dataset for the offline **Training System**.
+3.  The **Learning Engine** uses these traces to fine-tune the Teacher model via methods like GRPO (offline reinforcement learning) or GEPA (online prompt optimization).
+4.  The **Updated Teacher Model** is then redeployed, making the live SDK Runtime more effective on subsequent tasks.
+
+This architecture ensures that every task executed by the SDK becomes a learning opportunity that improves the entire system over time. For a detailed breakdown of the runtime loop, see [`How Orchestration Works`](/sdk/orchestration).

--- a/docs/concepts/reward-design.mdx
+++ b/docs/concepts/reward-design.mdx
@@ -118,6 +118,41 @@ rim:
 - **Offline training**: Disable `accuracy` and `diagnostic`, focus on `helpfulness` and `process`
 - **Online evaluation**: Enable all four judges for comprehensive scoring
 
+## Reward System in the Atlas SDK
+
+The SDK runtime uses the same reward philosophy to control its execution loop. The `rim` block in `configs/examples/sdk_quickstart.yaml` defines the judges, arbiter, and thresholds that trigger retries.
+
+```yaml
+# configs/examples/sdk_quickstart.yaml
+rim:
+  judges:
+    - identifier: process
+      kind: process
+      weight: 0.6
+      # ...
+    - identifier: helpfulness
+      kind: helpfulness
+      weight: 0.4
+      # ...
+  arbiter:
+    # ...
+  success_threshold: 0.7
+  retry_threshold: 0.6
+```
+
+During orchestration, this configuration tells the runtime how to behave:
+
+1. After a step is executed, the `Teacher` sends the output to the Reward System for evaluation.
+2. The `process` and `helpfulness` judges score the attempt.
+3. If the final score is below the `retry_threshold` (0.6), the `Teacher` generates guidance and the `Student` retries the step.
+4. If the score is above the `success_threshold` (0.7), the step is approved and the orchestrator moves to the next one.
+
+<Tip>
+Want a stricter runtime? Raise the `success_threshold` in your config or add a new, domain-specific judge. See the [`SDK Configuration Reference`](/sdk/configuration#reward-system-the-rim-block) for complete syntax.
+</Tip>
+
+This mirrors the training world: the runtime uses rewards to keep the agent on track, while the training process uses the same signals to improve the underlying models.
+
 ## Using the Reward System
 
 ### In Training (Offline RL)

--- a/docs/concepts/teacher-student-paradigm.mdx
+++ b/docs/concepts/teacher-student-paradigm.mdx
@@ -28,6 +28,19 @@ Unlike fine-tuning or RLHF, which require modifying model weights, ATLAS works w
 | Risk of capability loss | Preserves all original capabilities |
 | Weeks to deploy changes | Hours to deploy improvements |
 
+## Runtime vs Training Context
+
+<Note>
+**Two ways to meet the Student and Teacher:** the SDK runtime uses them to execute a single task, while the training system uses them to *improve* future teachers.
+</Note>
+
+| Context | Where you see it | Student role | Teacher role | Goal |
+|---------|------------------|--------------|--------------|------|
+| **SDK Runtime** | [`sdk/quickstart`](/sdk/quickstart), [`How Orchestration Works`](/sdk/orchestration) | Plans, executes, and synthesizes answers using your adapter | Reviews plans, validates steps, and requests retries | Produce a high-quality answer right now |
+| **Training & Optimization** | [`Quickstart`](/quickstart), [`First Experiment`](/first-experiment) | The model being improved (e.g., teacher checkpoint) | The supervising coach generating training signals | Improve long-term model behavior |
+
+When writing or reading docs, look for the “Switching between Runtime and Training?” callout for navigation help. The in-depth runtime roles live at [`Student & Teacher Roles`](/sdk/student-teacher-roles).
+
 ## Why This Works
 
 ### 1. Asymmetric Specialization

--- a/docs/guides/configuration-guide.mdx
+++ b/docs/guides/configuration-guide.mdx
@@ -5,6 +5,12 @@ sidebarTitle: Configuration
 icon: sliders
 ---
 
+<Note>
+**Looking for SDK runtime configuration?** See the [SDK Configuration Reference](/sdk/configuration) for YAML keys that control `atlas.run`.
+
+This page focuses on training and optimization configuration for the ATLAS teacher stack.
+</Note>
+
 ## Quick Reference
 
 ATLAS uses configuration files to customize behavior without code changes. Here's what each directory contains:

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -12,25 +12,45 @@ Instead of treating your deployed agents as static systems that need constant re
 
 ATLAS works like a skilled tutor helping a student improve. Your existing AI model (GPT, Claude, Gemini, etc.) is the student. ATLAS provides a specialized teacher model that reviews the student's work, identifies gaps, and provides focused guidance—all at inference time.
 
-**Example:** When your GPT-5 student attempts a complex reasoning task, the ATLAS teacher reviews the attempt, provides targeted help (like "Your calculation approach is correct, but check the units"), and the student applies this guidance to produce an improved response.
-
 This delivers measurable results: **15.7% average accuracy improvement**, **97% non-degradation rate**, and **50% token reduction** across benchmarks.
 
-<div align="center">
-  <img src="/images/system-architecture.png" alt="ATLAS System Architecture" width="800" />
-  <p><em>ATLAS keeps your agent in a learn–evaluate–update cycle</em></p>
-</div>
+## Getting Started: Two Paths
+
+Atlas is a comprehensive framework with two primary entry points. Most teams begin with the SDK to orchestrate an existing agent, then graduate to the training workflows for deeper optimization.
+
+| I want to... | Use this Path | Key Docs |
+|--------------|----------|--------------|
+| Orchestrate tasks with a structured runtime loop. | Atlas SDK | [`SDK Quickstart`](/sdk/quickstart) |
+| Wrap my existing agent in a quality-control loop. | Atlas SDK | [`BYOA Adapters`](/sdk/adapters) |
+| Optimize prompts and teaching strategies. | Training & Optimization | [`Online Optimization`](/quickstart) |
+| Fine-tune a custom teacher model with RL. | Training & Optimization | [`Full Training Walkthrough`](/first-experiment) |
+
+Choose your starting point below:
+
+<CardGroup cols="2">
+  <Card title="SDK Runtime Orchestration" icon="workflow" href="/sdk/quickstart">
+    Use the Atlas orchestrator to run an existing agent with a Student-Teacher quality loop. Get started in minutes.
+  </Card>
+  <Card title="Model Training & Optimization" icon="graduation-cap" href="/quickstart">
+    Use online and offline learning to improve agent performance, optimize prompts, and fine-tune models with reinforcement learning.
+  </Card>
+</CardGroup>
 
 ## What ATLAS Provides
 
 ATLAS wraps your existing agent framework with four components that create a complete learning loop:
 
 1. **Reasoning Core**: A teacher-student model pair that enhances your agent's capabilities
-2. **[Reward System (RIM)](/concepts/reward-design)**: Turns user feedback into dense reward signals (achieves 93.7% accuracy on RewardBench V2)
-3. **Learning Engine**: Uses online methods like GEPA and offline methods like GRPO to update models based on rewards
+2. **[Reward System](/concepts/reward-design)**: Turns user feedback into dense reward signals (achieves 93.7% accuracy on RewardBench V2)
+3. **Learning Engine**: Uses online optimization and offline reinforcement learning (e.g., GEPA, GRPO) to update models based on rewards
 4. **Persistent Memory**: Stores all interactions in structured trace files for analysis and retraining
 
 Together, these components form a closed-loop system: interaction traces flow into the reward system, the learning engine upgrades the teacher-student core, and the refreshed models redeploy so your agent gets sharper with every episode.
+
+<div align="center">
+  <img src="/images/system-architecture.png" alt="ATLAS System Architecture" width="800" />
+  <p><em>ATLAS keeps your agent in a learn–evaluate–update cycle</em></p>
+</div>
 
 ## Compared to Alternatives
 
@@ -52,46 +72,6 @@ ATLAS provides three modes that work together in a complete learning cycle:
 **3. [Train](/first-experiment)** – When you need more than prompt tweaks, use the judged data to update the teacher model weights via reinforcement learning.
 
 This evaluate → optimize → train arc creates a continual learning loop: fresh interactions enter the reward system, signals decide what to keep or discard, and ATLAS updates the teaching components so your deployed agent never goes stale.
-
-## Getting Started: Two Paths
-
-<CardGroup cols="2">
-  <Card title="Pre-trained ATLAS Models" icon="box">
-    **Best for: 99% of use cases**
-
-    - Works across all domains out-of-the-box
-    - Adapts to your tasks via online optimization
-    - No training infrastructure required
-    - Available immediately on HuggingFace
-  </Card>
-  <Card title="Custom Teacher Training" icon="graduation-cap">
-    **Best for: Specialized domains**
-
-    - Proprietary knowledge not in public models
-    - Regulatory compliance requirements
-    - Extreme performance optimization needs
-    - Requires multi-GPU setup
-  </Card>
-</CardGroup>
-
-## Next Steps
-
-<CardGroup cols="2">
-  <Card
-    title="Quickstart: Pre-trained Models"
-    icon="play"
-    href="/quickstart"
-  >
-    Deploy ATLAS in minutes using pre-trained teacher models. No training required.
-  </Card>
-  <Card
-    title="Custom Training"
-    icon="graduation-cap"
-    href="/first-experiment"
-  >
-    Build a custom teacher model optimized for your specific domain and requirements.
-  </Card>
-</CardGroup>
 
 ## Research & Resources
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -53,6 +53,16 @@
       ]
     },
     {
+      "group": "SDK Runtime",
+      "pages": [
+        "sdk/quickstart",
+        "sdk/configuration",
+        "sdk/orchestration",
+        "sdk/adapters",
+        "sdk/student-teacher-roles"
+      ]
+    },
+    {
       "group": "Core Concepts",
       "pages": [
         "concepts/teacher-student-paradigm",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -15,6 +15,12 @@ There are two primary paths for getting started with ATLAS. For most users, we r
 </Info>
 
 <Note>
+**Looking for the SDK runtime quickstart?** See [SDK Quickstart](/sdk/quickstart) to start orchestrating tasks with any agent.
+
+This page covers training and optimization workflows.
+</Note>
+
+<Note>
 **Quick Terminology**: In ATLAS, a "student" is any LLM or agent you want to enhance - GPT, Claude, Gemini, your custom API, etc. The "teacher" (our pre-trained ATLAS model) guides your student without modifying it.
 </Note>
 
@@ -29,7 +35,7 @@ python examples/quickstart/evaluate.py \
   --student-model gpt-4o-mini
 ```
 
-The script prints the baseline response, teacher guidance, the improved response, and [RIM (Reward System)](/concepts/reward-design) scores that measure the quality improvement. Configure models or token limits with CLI flags when needed.
+The script prints the baseline response, teacher guidance, the improved response, and [Reward System](/concepts/reward-design) scores that measure the quality improvement. Configure models or token limits with CLI flags when needed.
 
 Make sure you export both `OPENAI_API_KEY` and `GEMINI_API_KEY` before running the command.
 
@@ -52,7 +58,7 @@ This script runs the complete ATLAS protocol:
 1. Gets a baseline response from the student model
 2. Teacher analyzes it and provides guidance
 3. Student retries with the teaching
-4. RIM scores both to measure improvement
+4. The Reward System scores both to measure improvement
 
 You'll see output like this:
 

--- a/docs/sdk/adapters.mdx
+++ b/docs/sdk/adapters.mdx
@@ -1,0 +1,137 @@
+---
+title: Bring Your Own Agent
+description: Connect the Atlas orchestrator to any agent via OpenAI, Python, or HTTP adapters.
+sidebarTitle: Agent Adapters
+icon: plug
+---
+
+Atlas SDK follows a simple promise: **your agent, our orchestration**. Adapters create a small, consistent interface so you can place the Student-Teacher loop on top of nearly anything—from hosted APIs to local Python functions.
+
+## Choosing an Adapter
+
+| Adapter | Use when… | Strengths | Things to watch |
+|---------|-----------|-----------|-----------------|
+| `openai` | You have an OpenAI or Azure OpenAI chat model. | Minimal setup, native tool calling, streaming support. | Only works with OpenAI-compatible APIs. |
+| `http_api` | Your agent already runs behind an HTTP endpoint. | Language-agnostic, deploy-anywhere. | You define the payload schema, handle auth, and parse responses. |
+| `python` | You want to call local functions or LangChain runnables directly. | Lowest latency, easy debugging. | Runs inside the orchestrator process—ensure your code is safe and performant. |
+
+```mermaid
+graph LR
+    Student -->|Sends Prompt| Adapter
+    Adapter -->|Makes Request| Agent
+    Agent -->|Returns Response| Adapter
+    Adapter -->|Provides Trace & Output| Student
+    Student -->|Sends Context| Teacher
+    Teacher -->|Provides Guidance| Student
+```
+
+## OpenAI Adapter (`atlas/agent/openai_adapter.py`)
+
+This is the fastest way to get started, especially with GPT-4o-mini or Azure OpenAI models.
+
+```yaml
+agent:
+  type: openai
+  name: sdk-quickstart-openai
+  system_prompt: |
+    You are the Atlas Student. Be concise and helpful.
+  tools: []
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.0
+    max_output_tokens: 768
+```
+
+- Supports conversation history and tool call metadata automatically.
+- Accepts `response_format` for JSON mode.
+- For Claude, Gemini, or other models, use the `http_api` adapter.
+
+## HTTP Adapter (`atlas/agent/http_adapter.py`)
+
+Best for microservices, serverless functions, or non-Python agents.
+
+```yaml
+agent:
+  type: http_api
+  name: example-http-agent
+  transport:
+    base_url: https://agent.example.com/run
+    headers:
+      Authorization: Bearer $AGENT_TOKEN
+    timeout_seconds: 60
+    retry:
+      attempts: 3
+      backoff_seconds: 1.0
+  payload_template:
+    mode: inference
+  result_path:
+    - data
+    - output
+```
+
+Wrap any service that accepts a JSON request. You define:
+
+- **`payload_template`**: The base JSON payload; the adapter injects the `prompt` and optional metadata.
+- **`result_path`**: A list of keys to traverse in the JSON response to find the agent's output string.
+- **Auth & retries**: Handled via the `transport` block, which mirrors `httpx` settings.
+
+## Python Adapter (`atlas/agent/python_adapter.py`)
+
+Ideal when your agent is a local Python function or a LangChain runnable.
+
+```yaml
+agent:
+  type: python
+  name: example-python-agent
+  import_path: agents.python_example
+  attribute: run_agent
+  working_directory: ./
+  allow_generator: false
+```
+
+- The adapter imports the `attribute` (e.g., `run_agent`) from the `import_path` module.
+- If the callable is async, the adapter awaits it; sync functions run in a background thread.
+- Set `allow_generator: true` to let the adapter consume a generator, concatenating all yielded strings into a single output.
+
+## Building Custom Adapters
+
+All adapters share a minimal interface (`AgentAdapter`). To add a new one (e.g., for gRPC), follow these steps:
+
+1. Extend the `AdapterType` enum in `atlas/config/models.py`.
+2. Implement a class inheriting from `AgentAdapter`.
+3. Register it in `atlas/agent/__init__.py`.
+
+```python
+from atlas.agent.registry import AgentAdapter, register_adapter
+from atlas.config.models import AdapterType
+
+class GRPCAdapter(AgentAdapter):
+    async def ainvoke(self, prompt: str, metadata: dict | None = None) -> str:
+        # 1. Connect to your gRPC service.
+        # 2. Build the request from the prompt.
+        # 3. Execute the call and get a response.
+        # 4. Return the response as a string.
+        return f"Response for prompt: {prompt}"
+
+# Assumes you've added GRPC to the AdapterType enum
+register_adapter(AdapterType.GRPC, GRPCAdapter)
+```
+
+Most teams start by copying the `http_api` adapter and swapping the transport layer.
+
+## Decision Checklist
+
+| Need | Recommendation |
+|------|----------------|
+| Fastest time-to-first-run | `openai` adapter with `sdk_quickstart.yaml`. |
+| Reuse an existing microservice | `http_api` adapter with proper retries and auth. |
+| Full control in local experiments | `python` adapter calling your local function. |
+| Access non-OpenAI APIs (Claude, Gemini, etc.) | Wrap them with the `http_api` adapter. |
+
+## Next Steps
+
+- Configure the rest of the runtime in [`SDK Configuration`](/sdk/configuration).
+- See how the orchestrator uses your adapter in [`How Orchestration Works`](/sdk/orchestration).
+- Clarify Student vs Teacher responsibilities in [`Student & Teacher Roles`](/sdk/student-teacher-roles).

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -1,0 +1,219 @@
+---
+title: SDK Configuration Reference
+description: Understand every block in an Atlas SDK YAML file so you can tailor the orchestrator to your agents.
+sidebarTitle: Configuration
+icon: settings
+---
+
+Atlas SDK configs are the control tower for runtime orchestration. Each block in the YAML tells the Student, Teacher, and Reward System how to behave. Start with `configs/examples/sdk_quickstart.yaml`, then graduate to the richer examples in `configs/examples/openai_agent.yaml`, `http_agent.yaml`, and `python_agent.yaml`.
+
+<Note>
+All examples reference files in the Atlas SDK repo (`configs/examples/`). If you cloned the repo for the quickstart, you already have them.
+</Note>
+
+## Layout at a Glance
+
+```yaml
+agent:        # How to talk to your underlying model or service
+student:      # Planner, executor, and synthesizer prompts/limits
+teacher:      # Reviewer and validator settings
+orchestration:# Runtime policies like retries and timeouts
+rim:          # Defines the Reward System (judges, arbiter, thresholds)
+storage:      # (Optional) Postgres connection for trace persistence
+prompt_rewrite: # (Optional) Persona rewriting before the run starts
+```
+
+Each section is restrictive by design—unexpected keys raise validation errors—so it’s easier to debug mistakes before the orchestrator spins up.
+
+## Agent Configuration (`agent`)
+
+This block defines how the orchestrator communicates with your agent.
+
+| Adapter | Best for | Key fields |
+|---------|----------|------------|
+| `openai` | OpenAI or Azure OpenAI chat models | `llm` block (model, key env var, temperature, token limits) |
+| `http_api` | Remote services behind an HTTP interface | `transport` (base URL, retry policy), `payload_template`, `result_path` |
+| `python` | Local Python functions or callables | `import_path`, `attribute`, `working_directory`, optional `llm` metadata |
+
+### OpenAI Adapter Example
+```yaml
+agent:
+  type: openai
+  name: sdk-quickstart-openai
+  system_prompt: |
+    You are the Atlas Student. Be concise and thorough.
+  tools: []
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.0
+    max_output_tokens: 768
+```
+<Tip>
+Any non-OpenAI-compatible API (like Anthropic Claude) should use the `http_api` adapter until a dedicated integration is available.
+</Tip>
+
+See [`Bring Your Own Agent`](/sdk/adapters) for full walkthroughs of all three adapters.
+
+## Student Configuration (`student`)
+
+The Student block shapes planning, execution, and synthesis.
+
+```yaml
+student:
+  prompts:
+    planner: |
+      {base_prompt}
+      Draft a numbered plan as JSON.
+    executor: |
+      {base_prompt}
+      Execute the step, showing intermediate reasoning.
+    synthesizer: |
+      {base_prompt}
+      Combine results into the final answer.
+  max_plan_tokens: 1024
+  max_step_tokens: 1024
+  max_synthesis_tokens: 1024
+  tool_choice: auto
+```
+
+- **Prompts**: Templates that receive `{base_prompt}` from the agent’s system prompt and any prompt rewriting.
+- **Token limits**: Guardrails for LLM calls; increase them when steps are truncated.
+- **`tool_choice`**: `auto` lets the Student call registered tools. Use `required` to force a tool call on every step.
+
+## Teacher Configuration (`teacher`)
+
+The Teacher reviews plans, validates outputs, and provides guidance.
+
+```yaml
+teacher:
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.1
+    max_output_tokens: 768
+  max_review_tokens: 1024
+  plan_cache_seconds: 300
+  guidance_max_tokens: 256
+  validation_max_tokens: 256
+```
+
+- **LLM block**: Often mirrors the Student’s provider but can be a more powerful model for complex reviews.
+- **`plan_cache_seconds`**: Caches an approved plan for a given task ID to avoid re-running reviews.
+- **Guidance/validation caps**: Keep feedback concise; increase when you expect lengthy traces.
+
+## Orchestration (`orchestration`)
+
+These policies govern the runtime loop.
+
+```yaml
+orchestration:
+  max_retries: 1
+  step_timeout_seconds: 600
+  rim_guidance_tag: rim_feedback
+  emit_intermediate_steps: true
+```
+
+- **`max_retries`**: Default is 1; increase to allow for more revision loops.
+- **`step_timeout_seconds`**: Per-step timeout; extend when calling slow tools or external APIs.
+- **`rim_guidance_tag`**: The tag used to inject feedback from the Reward System back into prompts.
+- **`emit_intermediate_steps`**: Keep `true` to stream events for logging and telemetry. (Note: Telemetry dashboards are not yet documented).
+
+## Reward System (the `rim` block)
+
+The Reward System scores each attempt so the orchestrator knows whether to accept an answer or trigger a retry. The YAML block is named `rim` for compatibility with the core training engine.
+
+```yaml
+rim:
+  judges:
+    - identifier: process
+      kind: process
+      weight: 0.6
+      principles:
+        - Follows user instructions
+      llm:
+        provider: openai
+        model: gpt-4o-mini
+        api_key_env: OPENAI_API_KEY
+        temperature: 0.0
+        max_output_tokens: 512
+    - identifier: helpfulness
+      kind: helpfulness
+      weight: 0.4
+      principles:
+        - Provides useful answers
+      llm:
+        provider: openai
+        model: gpt-4o-mini
+        api_key_env: OPENAI_API_KEY
+        temperature: 0.0
+        max_output_tokens: 512
+  temperatures: [0.0, 0.3]
+  variance_threshold: 0.15
+  uncertainty_threshold: 0.3
+  arbiter:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.1
+    max_output_tokens: 512
+  success_threshold: 0.7
+  retry_threshold: 0.6
+  aggregation_strategy: weighted_mean
+```
+
+- **Judges**: At least one is required. Mix `process`, `helpfulness`, or custom judges to fit your domain.
+- **Arbiter**: A separate LLM that resolves disagreements between judges.
+- **Thresholds**: If a score is below `retry_threshold`, the Teacher is asked for guidance. Above `success_threshold`, the answer is accepted.
+
+Learn more in [`Reward Design`](/concepts/reward-design#reward-system-in-the-atlas-sdk).
+
+## Storage (`storage`)
+
+Optional Postgres persistence for traces and session metadata.
+
+```yaml
+storage:
+  database_url: postgresql://localhost:5432/atlas
+  min_connections: 1
+  max_connections: 5
+  statement_timeout_seconds: 30
+```
+
+Leave `storage: null` (as in the quickstart) when you don’t have a database. Enable it when you’re ready to collect sessions.
+
+## Prompt Rewrite (`prompt_rewrite`)
+
+This block lets an additional LLM tighten or extend Student/Teacher prompts before a run starts. The quickstart keeps this disabled (`prompt_rewrite: null`).
+
+```yaml
+prompt_rewrite:
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.1
+    max_output_tokens: 1024
+  max_tokens: 1024
+  temperature: 0.1
+```
+
+Enable it to tailor personas dynamically—for example, to compress a long system prompt into a slimmer runtime context.
+
+## Cheat Sheet
+
+| Goal | Section to edit | Quick pointer |
+|------|-----------------|---------------|
+| Swap to Anthropic via HTTP | `agent` | Use the `http_api` adapter and point `transport.base_url` to your service. |
+| Increase reasoning depth | `student` and `teacher` | Raise the `max_..._tokens` limits for the planner, executor, or guidance. | 
+| Persist sessions | `storage` | Provide a reachable Postgres URL and credentials. |
+| Tighten the quality bar | `rim` | Increase the `success_threshold` in the Reward System or add a new judge. |
+| Personalize prompts | `prompt_rewrite` | Enable the block and configure the rewrite LLM. |
+
+## Next Steps
+
+- Walk through the runtime loop in [`How Orchestration Works`](/sdk/orchestration).
+- Choose the right connector in [`Bring Your Own Agent`](/sdk/adapters).
+- See how runtime roles compare to training in [`Student & Teacher Roles`](/sdk/student-teacher-roles).

--- a/docs/sdk/orchestration.mdx
+++ b/docs/sdk/orchestration.mdx
@@ -1,0 +1,88 @@
+---
+title: How Orchestration Works
+description: Follow the Student, Teacher, and Reward System as they coordinate an Atlas SDK run from plan to final answer.
+sidebarTitle: Orchestration
+icon: workflow
+---
+
+The Atlas SDK orchestrator is an orchestra conductor: it keeps every section in sync, brings instruments in at the right moment, and signals when the piece is ready for applause. Let’s walk through the score.
+
+## The Runtime Workflow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Student
+    participant Teacher
+    participant Reward System
+
+    User->>Student: Task request
+    Student->>Teacher: Draft plan
+    Teacher->>Student: Approved plan
+    Student->>Student: Execute step
+    Student->>Teacher: Share trace & output
+    Teacher->>Reward System: Request score
+    Reward System-->>Teacher: Return score & notes
+    Teacher->>Student: Validation / guidance
+    Student-->>User: Final answer
+```
+
+1. **Plan Creation**: The `Student` proposes a step-by-step plan to accomplish the task (`Student.acreate_plan`).
+2. **Plan Review**: The `Teacher` approves or rewrites the plan before execution begins (`Teacher.areview_plan`).
+3. **Dependency Graph**: The orchestrator sorts the steps to ensure prerequisites run first (`atlas/orchestration/orchestrator.py`).
+4. **Step Execution**: The `Student` executes each step, streaming tool calls and traces into the `ExecutionContext` (`Student.aexecute_step`).
+5. **Validation Loop**: The `Teacher` validates the output of each step (`avalidate_step`). If validation fails, it can request guidance.
+6. **Evaluation**: The Reward System scores the full attempt (`atlas/reward/evaluator.py`). A score below the configured `retry_threshold` will trigger a retry.
+7. **Final Synthesis**: Once all steps are successfully executed and validated, the `Student` combines the results into a final answer (`asynthesize_final_answer`).
+
+## Retries & Guidance
+
+Retries are surgical. When a judge score falls below `retry_threshold`, the orchestrator:
+
+1. Calls `Teacher.agenerate_guidance` for actionable feedback.
+2. Records the guidance in the execution context so it shows up in logs.
+3. Replays the failing step with the new hints, up to `max_retries` attempts.
+
+Use this to tune how forgiving the runtime should be: raise `max_retries` for high-stakes workflows, or keep it at 1 to fail fast.
+
+## Event Stream & Telemetry
+
+Every significant action is published to the `ExecutionContext` event stream. Subscribe to it to power CLI streams, dashboards, or custom logging.
+
+```python
+from atlas.orchestration.execution_context import ExecutionContext
+
+context = ExecutionContext.get()
+subscription = context.event_stream.subscribe(print)
+```
+
+- **Intermediate steps** – emitted when plans start/end, steps begin/finish, and tool calls fire.
+- **Metadata** – stores guidance text, judge scores, and session metadata for later persistence.
+- **Telemetry hooks** – `atlas/core.py` allows a `TelemetryPublisher` to attach/detach. Dashboard documentation is coming later, so consider this a future-proofing hook.
+
+## Anatomy of `atlas.run`
+
+Open `atlas/core.py` to see the high-level flow:
+
+1. Load and validate the config (`atlas/config/loader.py`).
+2. Create the agent adapter via `create_from_atlas_config`.
+3. Optionally rewrite prompts, then instantiate Student, Teacher, and Evaluator.
+4. Spin up the orchestrator and optional Postgres session logging.
+5. Return an `atlas.types.Result` with the approved plan, per-step results, and final answer.
+
+This is the same flow you triggered in the quickstart—just packaged for reuse.
+
+## When to Customize
+
+| If you want to… | Tweak |
+|-----------------|-------|
+| Stream events into your UI | Subscribe to the event stream or write a `TelemetryPublisher`. |
+| Tighten quality control | Adjust thresholds in the `rim` block (e.g., `success_threshold`) or add new judges. |
+| Retry more aggressively | Raise `orchestration.max_retries` and tune guidance prompts. |
+| Record every attempt | Enable `storage` and audit the persisted steps. |
+
+## Next Steps
+
+- Configure each YAML block in detail with the [`SDK Configuration Reference`](/sdk/configuration).
+- Bring your own agent with the [`Bring Your Own Agent`](/sdk/adapters) guide.
+- See how runtime roles compare to training in [`Student & Teacher Roles`](/sdk/student-teacher-roles).

--- a/docs/sdk/quickstart.mdx
+++ b/docs/sdk/quickstart.mdx
@@ -1,0 +1,103 @@
+---
+title: Quickstart: Run Your First Task
+description: Launch the Atlas SDK runtime, run your first task, and understand how the Student–Teacher loop orchestrates work.
+sidebarTitle: Quickstart
+icon: rocket
+---
+
+This guide provides the fastest path to running the Atlas SDK. You will clone the repository, set an environment variable, and execute your first task.
+
+<Note>
+**Beta notice:** The Atlas SDK runtime is in beta. APIs and configuration keys may evolve—check release notes before upgrading.
+</Note>
+
+## Prerequisites
+
+<Note>
+Until the Atlas SDK is published on PyPI, install it directly from GitHub. When the package becomes public you can swap the first step for `pip install atlas-sdk`.
+</Note>
+
+1. **Clone the SDK repo and install in editable mode**
+   ```bash
+   git clone https://github.com/Arc-Computer/atlas-sdk
+   cd atlas-sdk
+   pip install -e .
+   ```
+2. **Set your LLM credentials**
+   ```bash
+   export OPENAI_API_KEY="sk-your-key"
+   ```
+   <Tip>
+   Using Azure OpenAI? Set the usual environment variables (`AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`) and update the config’s provider/model entries before running.
+   </Tip>
+3. **Use a modern version of Python.** The SDK is tested with Python 3.10 and newer.
+
+## Step 1 – Run the Quickstart Task
+
+The `sdk_quickstart.yaml` config is a lightweight configuration that disables storage and prompt rewriting, requiring only an `OPENAI_API_KEY` to get started.
+
+Save the following snippet to a file (e.g., `run_atlas.py`).
+
+```python
+from atlas import run
+
+result = run(
+    task="Summarize the latest AI news",
+    config_path="configs/examples/sdk_quickstart.yaml",
+)
+print(result.final_answer)
+```
+
+<Info>
+Alternatively, you can run the snippet directly in your terminal:
+```bash
+python -c "from atlas import run; result = run(task='Summarize the latest AI news', config_path='configs/examples/sdk_quickstart.yaml'); print(result.final_answer)"
+```
+</Info>
+
+You should see a short plan-reason-synthesize cycle: the Student drafts a plan, the Teacher verifies it, steps execute, and the final answer prints to your terminal.
+
+## What Just Happened?
+
+Think of `atlas.run` as a project manager who never gets tired:
+
+- **Configure** – the YAML tells the manager which agent to call and how the Student/Teacher/Reward System trio should behave.
+- **Plan** – the Student drafts a step-by-step approach for the Teacher to check.
+- **Review** – the Teacher approves or tweaks the plan before anything runs.
+- **Execute** – each step runs in order, with the Teacher validating outputs.
+- **Evaluate** – the Reward System scores the work, deciding whether retries or guidance are needed.
+
+```mermaid
+graph LR
+    A[Configure] --> B[Plan]
+    B --> C[Review]
+    C --> D[Execute]
+    D --> E[Evaluate]
+```
+
+## Configuration Breakdown
+
+The `sdk_quickstart.yaml` config defines the runtime behavior. Here’s a high-level look at the key sections:
+
+- **`agent`**: Specifies the agent to run the task. The quickstart uses the OpenAI adapter with `gpt-4o-mini` and no tools, requiring only an `OPENAI_API_KEY`.
+- **`student`**: Configures the planner, executor, and synthesizer roles with their respective prompts and token limits.
+- **`teacher`**: Defines the review and guidance agent, which also has its own model and token budget.
+- **`orchestration`**: Sets runtime parameters like the number of retries (default: 1) and step timeouts.
+- **`reward_system`**: Defines the judges and arbiter that score the final answer for quality and helpfulness. This score determines if a retry is needed.
+- **`storage`**: Set to `null` to disable Postgres persistence for a lightweight start.
+- **`prompt_rewrite`**: Also `null`. The SDK won't rewrite prompts for persona or style unless you enable this feature.
+
+To add tools, enable persistence, or use a different agent, switch the `config_path` to a more advanced configuration like `configs/examples/openai_agent.yaml` and see the `SDK Configuration` reference for details.
+
+## Troubleshooting Checklist
+
+- **Missing API key** – ensure `OPENAI_API_KEY` (or Azure equivalents) are exported in the same shell.
+- **Time spent downloading dependencies** – editable installs pull in `litellm`, `httpx`, and friends on the first run; subsequent runs are instant.
+- **Model limits** – bump `max_output_tokens` in the config if your summaries get truncated.
+
+## Next Steps
+
+- Dive into [`SDK Configuration`](/sdk/configuration) to customize each YAML block.
+- Learn how the planner, reviewer, and evaluator cooperate in [`How Orchestration Works`](/sdk/orchestration).
+- Wrap your own agent with the adapters in [`Bring Your Own Agent`](/sdk/adapters).
+- Compare runtime vs training expectations in [`Student & Teacher Roles`](/sdk/student-teacher-roles).

--- a/docs/sdk/student-teacher-roles.mdx
+++ b/docs/sdk/student-teacher-roles.mdx
@@ -1,0 +1,88 @@
+---
+title: Student & Teacher Roles
+description: Understand how the Student and Teacher collaborate at runtime and how those roles differ from ATLAS training.
+sidebarTitle: Student & Teacher
+icon: users
+---
+
+In Atlas, the terms “Student” and “Teacher” are used in two primary contexts: the SDK runtime and model training. While the names are the same, their responsibilities shift.
+
+<Note>
+**Runtime vs. Training:** The SDK runtime focuses on orchestrating an existing agent to complete a task. Model training focuses on optimizing a model’s performance for future tasks.
+</Note>
+
+## Two Contexts, One Vocabulary
+
+| Context | Student | Teacher | Primary Goal |
+|---------|---------|---------|---------------|
+| **SDK Runtime** | The planner, executor, and synthesizer that calls your agent. | The plan reviewer, output validator, and guidance author. | Deliver a reliable answer for the current task. |
+| **Model Training** | The model being improved (e.g., a new policy checkpoint). | The supervising model providing feedback during optimization. | Improve the long-term performance of the Student model. |
+
+The runtime roles are defined in `atlas/roles/`, while the training roles are part of the broader Atlas training system.
+
+## The Runtime Student
+
+Located in `atlas/roles/student.py`, the runtime Student performs three key actions:
+
+1. **Plan**: Creates a dependency graph to solve the task (`acreate_plan`). The prompt for this is set in `student.prompts.planner`.
+2. **Execute**: Runs each step from the plan, calling any necessary tools or adapters (`aexecute_step`).
+3. **Synthesize**: Compiles the results from all steps into a final answer for the user (`asynthesize_final_answer`).
+
+Key configuration levers include prompt templates (`student.prompts`), token budgets (`max_*_tokens`), and tool behavior (`tool_choice`).
+
+## The Runtime Teacher
+
+Defined in `atlas/roles/teacher.py`, the runtime Teacher acts as the quality assurance layer.
+
+1. **Plan Review**: Approves or rejects the Student's plan before execution (`areview_plan`).
+2. **Validation**: Checks the output of each step to ensure it meets quality standards (`avalidate_step`).
+3. **Guidance**: If an output is poor, it generates feedback to guide the Student on the next attempt (`agenerate_guidance`).
+
+Configuration options include the Teacher's LLM (`teacher.llm`), token limits for feedback (`max_review_tokens`), and plan caching (`plan_cache_seconds`).
+
+## The Runtime Feedback Loop
+
+The Student and Teacher collaborate in a tight loop to ensure quality.
+
+```mermaid
+sequenceDiagram
+    participant Student
+    participant Teacher
+    participant RewardSystem as Reward System
+
+    Student->>Teacher: Propose Plan
+    Teacher-->>Student: Approve Plan
+    loop For each step in Plan
+        Student->>Student: Execute Step
+        Student->>Teacher: Submit Output & Trace
+        Teacher-->>Teacher: Validate Step
+        alt Validation Fails or Score is Low
+            Teacher->>RewardSystem: Request Score
+            RewardSystem-->>Teacher: Return Score
+            opt Score < retry_threshold
+                Teacher->>Student: Provide Guidance for Retry
+            end
+        end
+    end
+    Student->>Student: Synthesize Final Answer
+```
+
+1. The Teacher must approve the Student's plan before any work begins.
+2. After each step, the Teacher validates the output. If the output is low-quality, it engages the Reward System.
+3. If the Reward System's score is below the `retry_threshold`, the Teacher generates guidance, and the Student attempts the step again.
+4. Once all steps pass validation, the Student synthesizes the final answer.
+
+## Summary: Runtime vs. Training
+
+To keep the contexts clear, remember this summary:
+
+- In the **SDK runtime**, the Student is the *doer* (planner/executor) and the Teacher is the *reviewer*.
+- In **model training**, the Student is the *model being improved*, and the Teacher is the *expert coach* providing feedback.
+
+When you see documentation referencing GEPA, GRPO, or reward shaping, you are in the training context. When you see talk of adapters and orchestration, you are in the SDK runtime context.
+
+## Next Steps
+
+- Explore the YAML knobs in [`SDK Configuration`](/sdk/configuration).
+- See the Student and Teacher in motion in [`How Orchestration Works`](/sdk/orchestration).
+- Jump into training workflows with the [Training Quickstart](/quickstart) or your [First Experiment](/first-experiment).

--- a/examples/sdk/01_minimal_example.py
+++ b/examples/sdk/01_minimal_example.py
@@ -1,0 +1,11 @@
+"""Run the Atlas SDK quickstart configuration end-to-end."""
+
+from atlas import run
+
+
+if __name__ == "__main__":
+    result = run(
+        task="Summarize the latest AI news",
+        config_path="configs/examples/sdk_quickstart.yaml",
+    )
+    print(result.final_answer)

--- a/examples/sdk/02_custom_adapter.py
+++ b/examples/sdk/02_custom_adapter.py
@@ -34,15 +34,15 @@ CONFIG_TEMPLATE = textwrap.dedent(
     student:
       prompts:
         planner: |
-          {{base_prompt}}
+          {base_prompt}
 
           Break the task into two concise steps as JSON.
         executor: |
-          {{base_prompt}}
+          {base_prompt}
 
           Call the HTTP agent and describe the result.
         synthesizer: |
-          {{base_prompt}}
+          {base_prompt}
 
           Summarize the findings clearly for the user.
       max_plan_tokens: 512

--- a/examples/sdk/02_custom_adapter.py
+++ b/examples/sdk/02_custom_adapter.py
@@ -1,0 +1,158 @@
+"""Wrap a simple HTTP microservice with the Atlas SDK."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import textwrap
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+from atlas import run
+
+CONFIG_TEMPLATE = textwrap.dedent(
+    """
+    agent:
+      type: http_api
+      name: sdk-http-example
+      system_prompt: |
+        You are an HTTP-based agent that echoes structured answers.
+      tools: []
+      transport:
+        base_url: http://127.0.0.1:{port}/agent
+        headers: {{}}
+        timeout_seconds: 30
+        retry:
+          attempts: 1
+          backoff_seconds: 0.5
+      payload_template:
+        mode: inference
+      result_path:
+        - output
+    student:
+      prompts:
+        planner: |
+          {base_prompt}
+
+          Break the task into two concise steps as JSON.
+        executor: |
+          {base_prompt}
+
+          Call the HTTP agent and describe the result.
+        synthesizer: |
+          {base_prompt}
+
+          Summarize the findings clearly for the user.
+      max_plan_tokens: 512
+      max_step_tokens: 512
+      max_synthesis_tokens: 512
+      tool_choice: auto
+    teacher:
+      llm:
+        provider: openai
+        model: gpt-4o-mini
+        api_key_env: OPENAI_API_KEY
+        temperature: 0.1
+        max_output_tokens: 512
+      max_review_tokens: 512
+      plan_cache_seconds: 60
+      guidance_max_tokens: 256
+      validation_max_tokens: 256
+    orchestration:
+      max_retries: 1
+      step_timeout_seconds: 120
+      rim_guidance_tag: rim_feedback
+      emit_intermediate_steps: true
+    rim:
+      judges:
+        - identifier: process
+          kind: process
+          weight: 0.5
+          principles:
+            - Followed instructions
+          llm:
+            provider: openai
+            model: gpt-4o-mini
+            api_key_env: OPENAI_API_KEY
+            temperature: 0.0
+            max_output_tokens: 256
+        - identifier: helpfulness
+          kind: helpfulness
+          weight: 0.5
+          principles:
+            - User impact
+          llm:
+            provider: openai
+            model: gpt-4o-mini
+            api_key_env: OPENAI_API_KEY
+            temperature: 0.0
+            max_output_tokens: 256
+      temperatures: [0.0, 0.3]
+      variance_threshold: 0.2
+      uncertainty_threshold: 0.3
+      arbiter:
+        provider: openai
+        model: gpt-4o-mini
+        api_key_env: OPENAI_API_KEY
+        temperature: 0.1
+        max_output_tokens: 256
+      success_threshold: 0.7
+      retry_threshold: 0.6
+      aggregation_strategy: weighted_mean
+    storage: null
+    prompt_rewrite: null
+    """
+)
+
+
+class EchoHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:  # noqa: N802 (http server signature)
+        length = int(self.headers.get("Content-Length", 0))
+        payload = json.loads(self.rfile.read(length)) if length else {}
+        prompt = payload.get("prompt", "")
+        response: dict[str, Any] = {
+            "output": f"Echo service received: {prompt[:100]}"
+        }
+        body = json.dumps(response).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: Any, **_kwargs: Any) -> None:  # Silence default logging
+        return
+
+
+def run_server(port: int) -> HTTPServer:
+    server = HTTPServer(("127.0.0.1", port), EchoHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def write_temp_config(port: int) -> str:
+    rendered = CONFIG_TEMPLATE.format(port=port)
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False)
+    tmp.write(rendered)
+    tmp.flush()
+    tmp.close()
+    return tmp.name
+
+
+if __name__ == "__main__":
+    port = 8040
+    server = run_server(port)
+    config_path = write_temp_config(port)
+    try:
+        result = run(
+            task="Ask the HTTP agent to list one interesting AI news headline",
+            config_path=config_path,
+        )
+        print(result.final_answer)
+    finally:
+        server.shutdown()
+        server.server_close()
+        Path(config_path).unlink(missing_ok=True)

--- a/examples/sdk/03_error_handling.py
+++ b/examples/sdk/03_error_handling.py
@@ -1,0 +1,44 @@
+"""Demonstrate retry awareness and structured errors from the Atlas SDK."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from atlas import run
+from atlas.agent.registry import AdapterError
+from atlas.types import StepResult
+
+CONFIG_PATH = "configs/examples/sdk_quickstart.yaml"
+
+
+def pretty_attempt(step_result: StepResult) -> dict[str, Any]:
+    return {
+        "step_id": step_result.step_id,
+        "output": step_result.output[:200],
+        "score": step_result.evaluation.get("reward", {}).get("score"),
+        "attempts": step_result.attempts,
+    }
+
+
+def main() -> None:
+    try:
+        result = run(
+            task="List two recent breakthroughs in AI safety research",
+            config_path=CONFIG_PATH,
+        )
+    except AdapterError as exc:
+        print("Adapter failed:", exc)
+        return
+    except Exception as exc:  # Catch anything unexpected so tests can continue
+        print("Unexpected failure:", exc)
+        return
+
+    print("Final answer:\n", result.final_answer)
+    print("\nStep summary:")
+    for step in result.step_results:
+        print(json.dumps(pretty_attempt(step), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -1,0 +1,35 @@
+# Atlas SDK Runtime Examples
+
+These examples pair with the SDK Runtime documentation to show how to run, customize, and debug `atlas.run`.
+
+## Prerequisites
+
+1. Clone the SDK and install in editable mode:
+   ```bash
+   git clone https://github.com/Arc-Computer/atlas-sdk
+   cd atlas-sdk
+   pip install -e .
+   ```
+2. Export an API key compatible with the configuration you plan to use (the quickstart examples rely on `OPENAI_API_KEY`).
+
+## Example Index
+
+| File | Description |
+|------|-------------|
+| `01_minimal_example.py` | Runs the quickstart config end-to-end and prints the final answer. |
+| `02_custom_adapter.py` | Spins up a tiny HTTP echo service and wraps it with the HTTP adapter. |
+| `03_error_handling.py` | Shows how to catch adapter errors and inspect retry metadata. |
+
+## Running an Example
+
+From the root of the SDK repo:
+
+```bash
+python examples/sdk/01_minimal_example.py
+```
+
+Each script includes inline comments guiding you to the relevant docs page for deeper context:
+
+- [`sdk/quickstart`](../../docs/sdk/quickstart.mdx)
+- [`sdk/adapters`](../../docs/sdk/adapters.mdx)
+- [`sdk/orchestration`](../../docs/sdk/orchestration.mdx)


### PR DESCRIPTION
## Summary
- add a dedicated *SDK Runtime* section (navigation, quickstart, configuration, orchestration, adapters, student/teacher roles)
- update existing concepts/architecture pages to cross-link the runtime and reward system terminology
- add runnable SDK examples (`01_minimal_example.py`, `02_custom_adapter.py`, `03_error_handling.py`) and the quickstart config referenced in the docs
- note the SDK beta status and align wording across the site (Reward System vs. RIM, online/offline terminology)

## Testing
- `python examples/sdk/01_minimal_example.py`
- `python examples/sdk/02_custom_adapter.py`
- `python examples/sdk/03_error_handling.py`
- `npx mint broken-links` *(fails today because README.md contains legacy HTML tags; docs files otherwise parse locally)*
