### PR TITLE
Align runtime reward schema with trainer ingestion

### DIFF
--- a/atlas_core/__init__.py
+++ b/atlas_core/__init__.py
@@ -1,0 +1,2 @@
+"""Core Atlas shared utilities."""
+

--- a/atlas_core/runtime/__init__.py
+++ b/atlas_core/runtime/__init__.py
@@ -1,0 +1,18 @@
+"""Runtime schema definitions shared between SDK exports and offline trainers."""
+
+from .schema import (
+    AtlasRewardBreakdown,
+    AtlasJudgeBreakdown,
+    AtlasJudgeSample,
+    AtlasStepTrace,
+    AtlasSessionTrace,
+)
+
+__all__ = [
+    "AtlasRewardBreakdown",
+    "AtlasJudgeBreakdown",
+    "AtlasJudgeSample",
+    "AtlasStepTrace",
+    "AtlasSessionTrace",
+]
+

--- a/atlas_core/runtime/schema.py
+++ b/atlas_core/runtime/schema.py
@@ -1,0 +1,99 @@
+"""Shared dataclasses representing runtime reward and trace payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class AtlasJudgeSample:
+    """Fine-grained sample emitted by a reward judge."""
+
+    score: float
+    rationale: str
+    principles: List[Dict[str, Any]] = field(default_factory=list)
+    uncertainty: Optional[float] = None
+    temperature: Optional[float] = None
+
+
+@dataclass
+class AtlasJudgeBreakdown:
+    """Structured result from a single reward judge."""
+
+    identifier: str
+    score: float
+    rationale: str
+    principles: List[Dict[str, Any]] = field(default_factory=list)
+    samples: List[AtlasJudgeSample] = field(default_factory=list)
+    escalated: bool = False
+    escalation_reason: Optional[str] = None
+
+
+@dataclass
+class AtlasRewardBreakdown:
+    """Aggregated reward summary for a step or episode."""
+
+    score: float
+    judges: List[AtlasJudgeBreakdown] = field(default_factory=list)
+    rationale: Optional[str] = None
+    raw: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise to a JSON-friendly dict."""
+
+        return {
+            "score": self.score,
+            "rationale": self.rationale,
+            "judges": [
+                {
+                    "identifier": judge.identifier,
+                    "score": judge.score,
+                    "rationale": judge.rationale,
+                    "principles": judge.principles,
+                    "samples": [
+                        {
+                            "score": sample.score,
+                            "rationale": sample.rationale,
+                            "principles": sample.principles,
+                            "uncertainty": sample.uncertainty,
+                            "temperature": sample.temperature,
+                        }
+                        for sample in judge.samples
+                    ],
+                    "escalated": judge.escalated,
+                    "escalation_reason": judge.escalation_reason,
+                }
+                for judge in self.judges
+            ],
+            "raw": self.raw,
+        }
+
+
+@dataclass
+class AtlasStepTrace:
+    """Single plan step with execution, validation, and reward context."""
+
+    step_id: int
+    description: str
+    trace: str
+    output: str
+    reward: AtlasRewardBreakdown
+    tool: Optional[str] = None
+    tool_params: Dict[str, Any] = field(default_factory=dict)
+    context: Dict[str, Any] = field(default_factory=dict)
+    validation: Dict[str, Any] = field(default_factory=dict)
+    attempts: int = 1
+    guidance: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AtlasSessionTrace:
+    """Complete session exported from the runtime."""
+
+    task: str
+    final_answer: str
+    plan: Dict[str, Any]
+    steps: List[AtlasStepTrace]
+    session_metadata: Dict[str, Any] = field(default_factory=dict)

--- a/configs/data/runtime_traces.yaml
+++ b/configs/data/runtime_traces.yaml
@@ -1,0 +1,13 @@
+dataset_path: traces/export.jsonl
+eval_split_ratio: 0.1
+dataset_max_samples: null
+shuffle: true
+
+data_log_name: runtime_traces
+
+make_dataset_fn:
+  _target_: custom_data.runtime_trace_data.get_runtime_trace_dataset
+  export_path: ${dataset_path}
+  eval_split_ratio: ${eval_split_ratio}
+  dataset_max_samples: ${dataset_max_samples}
+  shuffle: ${shuffle}

--- a/custom_data/runtime_trace_data.py
+++ b/custom_data/runtime_trace_data.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from datasets import Dataset
+from transformers import PreTrainedTokenizer
+
+from trainers.runtime_dataset import (
+    load_runtime_traces,
+    sessions_to_rl_records,
+)
+
+
+def get_runtime_trace_dataset(
+    tokenizer: PreTrainedTokenizer,
+    export_path: str,
+    eval_split_ratio: float = 0.1,
+    dataset_max_samples: Optional[int] = None,
+    shuffle: bool = True,
+) -> Dict[str, Any]:
+    """Load runtime JSONL exports and prepare train/eval splits for RL."""
+
+    sessions = load_runtime_traces(export_path)
+    records = sessions_to_rl_records(sessions)
+
+    if dataset_max_samples is not None:
+        records = records[:dataset_max_samples]
+
+    dataset = Dataset.from_list(records)
+    if shuffle:
+        dataset = dataset.shuffle(seed=42)
+
+    if eval_split_ratio and 0 < eval_split_ratio < 1:
+        dataset_dict = dataset.train_test_split(test_size=eval_split_ratio, seed=42)
+        return {
+            "train_dataset": dataset_dict["train"],
+            "eval_dataset": dataset_dict["test"],
+        }
+
+    return {"train_dataset": dataset, "eval_dataset": None}
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function
+asyncio_default_test_loop_scope = function

--- a/tests/test_reward_schema.py
+++ b/tests/test_reward_schema.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+
+import pytest
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import yaml
+
+from RIM.reward_adapter import RIMReward
+from atlas_core.runtime import AtlasRewardBreakdown
+
+
+@pytest.fixture()
+def stub_config(tmp_path: Path) -> Path:
+    config = {
+        "rim": {
+            "temperatures": [0.2, 0.5],
+            "variance_threshold": 1.0,
+            "active_judges": {"accuracy": True},
+            "models": {
+                "small_model": "stub-small",
+                "large_model": "stub-large",
+            },
+            "parallel_execution": {"max_workers": 1},
+        }
+    }
+    path = tmp_path / "rim_config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def stubbed_model_interface(monkeypatch):
+    def _call_model(model_name, prompt, temperature, max_tokens):
+        if model_name == "stub-small":
+            return json.dumps(
+                {
+                    "score": 0.8,
+                    "uncertainty": 0.1,
+                    "rationale": "Small model rationale",
+                    "principles": [
+                        {"name": "Execution", "weight": 1.0, "description": "step quality"}
+                    ],
+                }
+            )
+        return json.dumps(
+            {
+                "score": 0.75,
+                "uncertainty": 0.2,
+                "rationale": "Arbiter fallback",
+                "principles": [
+                    {"name": "Consistency", "weight": 1.0, "description": "arbiter"}
+                ],
+            }
+        )
+
+    monkeypatch.setattr(
+        "RIM.model_interface.model_interface.call_model",
+        _call_model,
+    )
+    monkeypatch.setattr(
+        "RIM.judge_specs.get_judge_prompt",
+        lambda reward_type: (
+            "Question: {question}\n"
+            "Answer: {student_answer}\n"
+            "Principles: {constitution_principles}"
+        ),
+    )
+    monkeypatch.setattr(
+        "RIM.rim.RewardInterpretationModel._build_judge_prompt",
+        lambda self, trajectory, reward_type: "prompt",
+    )
+
+
+def test_rim_reward_emits_structured_breakdown(stub_config: Path):
+    reward_fn = RIMReward(config_path=str(stub_config))
+
+    evaluation = reward_fn.evaluate(
+        prompt="What is 2+2?",
+        response="The answer is <solution>4</solution>.",
+    )
+
+    assert isinstance(evaluation.reward, AtlasRewardBreakdown)
+    assert evaluation.reward.score == pytest.approx(0.8)
+    assert evaluation.reward.judges, "expected judge breakdown"
+    judge = evaluation.reward.judges[0]
+    assert judge.identifier == "accuracy"
+    assert judge.score == pytest.approx(0.8)
+    assert judge.rationale
+    assert judge.samples, "expected per-sample metadata"
+    sample = judge.samples[0]
+    assert sample.score == pytest.approx(0.8)
+    assert sample.uncertainty == pytest.approx(0.1)
+
+    last_structured = reward_fn.last_structured_rewards
+    assert last_structured, "last_structured_rewards should reflect latest batch"
+    assert last_structured[0].score == pytest.approx(0.8)

--- a/tests/test_runtime_dataset.py
+++ b/tests/test_runtime_dataset.py
@@ -1,0 +1,109 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from trainers.runtime_dataset import (
+    load_runtime_traces,
+    flatten_traces_for_training,
+    build_executor_prompt,
+    sessions_to_rl_records,
+)
+
+
+def test_load_runtime_traces_round_trip(tmp_path: Path):
+    payload = {
+        "task": "Solve problem A",
+        "final_answer": "answer",
+        "plan": {"steps": [{"id": 1, "description": "step"}]},
+        "session_metadata": {"dataset": "demo"},
+        "steps": [
+            {
+                "step_id": 1,
+                "description": "Compute baseline",
+                "trace": "HUMAN: do work",
+                "output": "result",
+                "evaluation": {
+                    "score": 0.9,
+                    "rationale": "Good job",
+                    "judges": [
+                        {
+                            "identifier": "accuracy",
+                            "score": 0.9,
+                            "rationale": "Matches reference",
+                            "principles": [{"name": "Accuracy", "weight": 1.0}],
+                            "samples": [
+                                {
+                                    "score": 0.9,
+                                    "rationale": "small-model",
+                                    "principles": [],
+                                    "uncertainty": 0.1,
+                                    "temperature": 0.2,
+                                }
+                            ],
+                            "escalated": False,
+                            "escalation_reason": None,
+                        }
+                    ],
+                },
+                "validation": {"valid": True},
+                "attempts": 1,
+                "guidance": ["keep going"],
+            }
+        ],
+    }
+    path = tmp_path / "export.jsonl"
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    sessions = load_runtime_traces(path)
+    assert len(sessions) == 1
+    session = sessions[0]
+    assert session.task == "Solve problem A"
+    assert session.steps[0].reward.score == 0.9
+    assert session.steps[0].reward.judges[0].identifier == "accuracy"
+    assert session.steps[0].reward.judges[0].samples[0].temperature == 0.2
+
+    flattened = flatten_traces_for_training(sessions)
+    assert len(flattened) == 1
+    record = flattened[0]
+    assert record["task"] == "Solve problem A"
+    assert record["reward_score"] == 0.9
+    assert record["reward_breakdown"]["judges"][0]["identifier"] == "accuracy"
+
+
+def test_sessions_to_rl_records_builds_prompt():
+    from atlas_core.runtime import AtlasSessionTrace, AtlasStepTrace, AtlasRewardBreakdown
+
+    reward = AtlasRewardBreakdown(score=0.8, judges=[], rationale="check", raw={"score": 0.8})
+    step = AtlasStepTrace(
+        step_id=1,
+        description="Retrieve baseline metrics",
+        trace="HUMAN: Step ID 1 ...",
+        output="baseline response",
+        reward=reward,
+        guidance=["Use cautious reasoning"],
+        validation={"valid": True},
+        context={"0": "prior output"},
+        tool="search",
+        tool_params={"query": "metrics"},
+        metadata={"executor_system_prompt": "You are the runtime executor."},
+    )
+    session = AtlasSessionTrace(
+        task="Diagnose outage",
+        final_answer="Resolved issue",
+        plan={"steps": [{"id": 1, "description": "Retrieve baseline metrics"}]},
+        steps=[step],
+        session_metadata={},
+    )
+
+    prompt_text = build_executor_prompt(step, session)
+    assert "Diagnose outage" in prompt_text
+    assert "Step ID: 1" in prompt_text
+    assert "Guidance History" in prompt_text
+
+    records = sessions_to_rl_records([session])
+    assert records[0]["prompt"] == prompt_text
+    assert records[0]["reward_breakdown"]["score"] == 0.8

--- a/trainers/__init__.py
+++ b/trainers/__init__.py
@@ -6,5 +6,6 @@ try:
         DataScorerArgs, DataTeacherRewardScorer,
         DataConcatenatorArgs, DataCompletionConcatenator)
     from RIM.reward_adapter import RIMReward
+    from .runtime_dataset import load_runtime_traces, flatten_traces_for_training
 except ImportError:
     pass

--- a/trainers/runtime_dataset.py
+++ b/trainers/runtime_dataset.py
@@ -1,0 +1,240 @@
+"""Utilities for consuming runtime JSONL exports in offline trainers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, List, Dict, Any, Sequence
+
+from atlas_core.runtime import (
+    AtlasRewardBreakdown,
+    AtlasJudgeBreakdown,
+    AtlasJudgeSample,
+    AtlasSessionTrace,
+    AtlasStepTrace,
+)
+
+
+def _coerce_reward(entry: Dict[str, Any]) -> AtlasRewardBreakdown:
+    judges_data: Sequence[Dict[str, Any]] = entry.get("judges") or []
+    judges: List[AtlasJudgeBreakdown] = []
+    for judge in judges_data:
+        samples_payload = judge.get("samples") or []
+        samples = [
+            AtlasJudgeSample(
+                score=sample.get("score", 0.0),
+                rationale=sample.get("rationale", ""),
+                principles=sample.get("principles", []) or [],
+                uncertainty=sample.get("uncertainty"),
+                temperature=sample.get("temperature"),
+            )
+            for sample in samples_payload
+        ]
+        judges.append(
+            AtlasJudgeBreakdown(
+                identifier=judge.get("identifier", ""),
+                score=judge.get("score", 0.0),
+                rationale=judge.get("rationale", ""),
+                principles=judge.get("principles", []) or [],
+                samples=samples,
+                escalated=bool(judge.get("escalated", False)),
+                escalation_reason=judge.get("escalation_reason"),
+            )
+        )
+    score = entry.get("score", 0.0)
+    rationale = entry.get("rationale")
+    raw_payload = entry.get("raw")
+    return AtlasRewardBreakdown(
+        score=score,
+        judges=judges,
+        rationale=rationale,
+        raw=raw_payload if isinstance(raw_payload, dict) else entry,
+    )
+
+
+def _coerce_step(step: Dict[str, Any]) -> AtlasStepTrace:
+    reward_payload = step.get("evaluation") or step.get("reward") or {}
+    reward = (
+        reward_payload
+        if isinstance(reward_payload, AtlasRewardBreakdown)
+        else _coerce_reward(reward_payload)
+    )
+    raw_context = step.get("context") or step.get("prior_results") or step.get("context_outputs")
+    if isinstance(raw_context, str):
+        try:
+            context = json.loads(raw_context)
+        except json.JSONDecodeError:
+            context = {"raw": raw_context}
+    else:
+        context = raw_context or {}
+
+    raw_tool_params = step.get("tool_params") or {}
+    if isinstance(raw_tool_params, str):
+        try:
+            tool_params = json.loads(raw_tool_params)
+        except json.JSONDecodeError:
+            tool_params = {"raw": raw_tool_params}
+    else:
+        tool_params = raw_tool_params or {}
+
+    tool_name = step.get("tool") or tool_params.get("name")
+    return AtlasStepTrace(
+        step_id=step.get("step_id", step.get("id", 0)),
+        description=step.get("description", ""),
+        trace=step.get("trace", ""),
+        output=step.get("output", ""),
+        reward=reward,
+        tool=tool_name,
+        tool_params=tool_params,
+        context=context if isinstance(context, dict) else {},
+        validation=step.get("validation", {}),
+        attempts=step.get("attempts", 1),
+        guidance=step.get("guidance", []) or [],
+        metadata={
+            key: value
+            for key, value in step.items()
+            if key
+            not in {
+                "step_id",
+                "id",
+                "description",
+                "trace",
+                "output",
+                "evaluation",
+                "reward",
+                "validation",
+                "attempts",
+                "guidance",
+                "context",
+                "context_outputs",
+                "prior_results",
+                "tool",
+                "tool_params",
+            }
+        },
+    )
+
+
+def _coerce_session(record: Dict[str, Any]) -> AtlasSessionTrace:
+    steps_field = record.get("steps") or []
+    steps = [_coerce_step(step) for step in steps_field]
+    return AtlasSessionTrace(
+        task=record.get("task", ""),
+        final_answer=record.get("final_answer", ""),
+        plan=record.get("plan", {}),
+        steps=steps,
+        session_metadata=record.get("session_metadata", {}) or {},
+    )
+
+
+def load_runtime_traces(path: str | Path) -> List[AtlasSessionTrace]:
+    """Load runtime traces exported as JSONL into structured dataclasses."""
+
+    path = Path(path)
+    sessions: List[AtlasSessionTrace] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            sessions.append(_coerce_session(payload))
+    return sessions
+
+
+def flatten_traces_for_training(
+    sessions: Iterable[AtlasSessionTrace],
+) -> List[Dict[str, Any]]:
+    """Flatten session traces into trainer-friendly dicts."""
+
+    records: List[Dict[str, Any]] = []
+    for session in sessions:
+        for step in session.steps:
+            records.append(
+                {
+                    "task": session.task,
+                    "final_answer": session.final_answer,
+                    "plan": session.plan,
+                    "step_id": step.step_id,
+                    "step_description": step.description,
+                    "step_trace": step.trace,
+                    "step_output": step.output,
+                    "attempts": step.attempts,
+                    "guidance_history": step.guidance,
+                    "step_context": step.context,
+                    "validation": step.validation,
+                    "tool": step.tool,
+                    "tool_params": step.tool_params,
+                    "reward_score": step.reward.score,
+                    "reward_breakdown": step.reward.to_dict(),
+                    "session_metadata": session.session_metadata,
+                    "step_metadata": step.metadata,
+                }
+            )
+    return records
+
+
+def build_executor_prompt(step: AtlasStepTrace, session: AtlasSessionTrace) -> str:
+    """Create a textual prompt mirroring the runtime executor input."""
+
+    system_prompt = (
+        step.metadata.get("executor_system_prompt")
+        or session.session_metadata.get("executor_system_prompt")
+        or "You are the Atlas Student executor. Follow the step instructions precisely."
+    )
+    context_block = json.dumps(step.context or {}, ensure_ascii=False, indent=2)
+    guidance_block = json.dumps(step.guidance or [], ensure_ascii=False, indent=2)
+    validation_block = json.dumps(step.validation or {}, ensure_ascii=False, indent=2)
+    payload = [
+        f"Task: {session.task}",
+        f"Step ID: {step.step_id}",
+        f"Description: {step.description}",
+        f"Tool: {step.tool or 'none'}",
+        f"Tool Parameters: {json.dumps(step.tool_params or {}, ensure_ascii=False)}",
+        f"Context: {context_block}",
+        f"Guidance History: {guidance_block}",
+        f"Previous Validation: {validation_block}",
+    ]
+    user_message = "\n".join(payload)
+    return f"{system_prompt}\n\n{user_message}"
+
+
+def sessions_to_rl_records(
+    sessions: Iterable[AtlasSessionTrace],
+) -> List[Dict[str, Any]]:
+    """Convert runtime sessions into RL-ready dataset records."""
+
+    records: List[Dict[str, Any]] = []
+    for session in sessions:
+        for step in session.steps:
+            prompt_text = build_executor_prompt(step, session)
+            record = {
+                "prompt": prompt_text,
+                "task": session.task,
+                "plan": session.plan,
+                "step_id": step.step_id,
+                "step_description": step.description,
+                "guidance_history": step.guidance,
+                "step_context": step.context,
+                "validation": step.validation,
+                "tool": step.tool,
+                "tool_params": step.tool_params,
+                "reward_breakdown": step.reward.to_dict(),
+                "reward_score": step.reward.score,
+                "step_output": step.output,
+                "step_trace": step.trace,
+                "session_metadata": session.session_metadata,
+            }
+            ground_truth = step.metadata.get("ground_truth") or session.session_metadata.get("ground_truth")
+            if ground_truth:
+                record["ground_truth"] = ground_truth
+            records.append(record)
+    return records
+
+
+def iter_reward_scores(sessions: Iterable[AtlasSessionTrace]) -> Iterator[float]:
+    """Yield reward scores from each step in the provided sessions."""
+
+    for session in sessions:
+        for step in session.steps:
+            yield step.reward.score


### PR DESCRIPTION
## Summary
- introduce shared runtime schema and loader so SDK exports feed directly into GRPO/Teacher trainers
- emit structured AtlasRewardBreakdown objects from RIMReward and thread guidance/context metadata through trainer prompts
- add runtime trace config, pytest config, and coverage for reward schema + dataset ingestion

## Testing
- pytest
- pytest tests/test_reward_schema.py tests/test_runtime_dataset.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Structured per-sample reward breakdowns exposed on evaluations and included in logged outputs and traces.
  * Runtime tracing schema (sessions/steps) with JSON-serializable reward and trace models.
  * Dataset utilities and a config to build/shuffle/split runtime trace datasets for training.

* Improvements
  * Evaluation results include per-judge records, principles, samples, escalation flags, and validated uncertainty.
  * Trainer prompt & record generation threaded with richer step context, guidance, validation, tools and reward info.

* Documentation
  * Added package docstring.

* Tests
  * New tests for reward breakdowns and runtime dataset utilities.

* Chores
  * Test runner asyncio defaults configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->