### PR TITLE
Docs: align with atlas-sdk implementation

### DIFF
--- a/docs/concepts/reward-design.mdx
+++ b/docs/concepts/reward-design.mdx
@@ -42,45 +42,44 @@ The system escalates to Tier 2 when either:
 
 Otherwise, it uses the most confident judgment from Tier 1—saving both time and money.
 
-## The Four Judges
+## Session-Level Evaluation
 
-Each judge evaluates a different dimension of quality:
+The reward system evaluates the complete trajectory after execution finishes. It derives 2-3 weighted principles tailored to the specific session, scores the trajectory against those principles, and extracts behavioral patterns for future learning.
 
-| Judge | What It Asks | Why It Matters |
-| :--- | :--- | :--- |
-| **AccuracyJudge** | "Is the answer correct?" | Core quality check for all tasks |
-| **HelpfulnessJudge** | "Did teaching make it better?" | Measures actual improvement from guidance |
-| **ProcessJudge** | "Is the reasoning sound?" | Rewards good problem-solving approach |
-| **DiagnosticJudge** | "Did we identify the real problem?" | Validates the teacher's assessment |
+### How It Works
 
-### How Judges Work
+The evaluator receives the full session context—task, plan, steps, final answer, execution mode—and generates a structured evaluation:
 
-Each judge is required to provide a structured rationale:
-
-**AccuracyJudge** generates evaluation principles first:
 ```json
 {
   "principles": [
-    {"name": "Correctness", "weight": 0.5, "description": "..."},
-    {"name": "Completeness", "weight": 0.3, "description": "..."}
+    {"name": "Correctness", "weight": 0.5, "description": "Final deliverable matches requirements"},
+    {"name": "Safety", "weight": 0.3, "description": "No policy violations detected"},
+    {"name": "Efficiency", "weight": 0.2, "description": "Minimal retries needed"}
   ],
   "score": 0.85,
-  "explanation": "The response correctly solves...",
-  "uncertainty": 0.1
+  "rationale": "Response solves the task correctly with efficient execution",
+  "uncertainty": 0.1,
+  "student_learning": "For straightforward tasks, proceed directly to solution without exploratory steps",
+  "teacher_learning": null
 }
 ```
 
-**HelpfulnessJudge** provides evidence list:
-```json
-{
-  "evidence": ["Student initially missed key concept", "Teaching provided specific guidance"],
-  "score": 0.75,
-  "explanation": "Teaching improved response quality by...",
-  "uncertainty": 0.15
-}
-```
+**Key components:**
+- **Principles**: Domain-relevant evaluation criteria with weights (sum to 1.0)
+- **Score**: Aggregated result in [0.0, 1.0] range
+- **Rationale**: Explanation grounded in the principles
+- **Student learning**: Cross-domain behavioral pattern to remember (not task-specific content)
+- **Teacher learning**: Pedagogical strategy that worked (when teacher provided guidance)
 
-This makes every score fully auditable—you can see exactly why a judgment was made.
+This makes every score fully auditable—you can see which principles were applied and why the judgment was made.
+
+## Defining Domain Objectives
+
+The judge prompt system lets you express quality criteria in natural language without training custom models. The evaluator derives 2-3 weighted principles tailored to each trajectory, scores against those principles, and reconciles multiple judge opinions through the ensemble flow.
+
+**How it works:**
+The `focus_prompt` field in `adaptive_teaching.reward` accepts arbitrary evaluation criteria. The judge reads that prompt, generates domain-relevant principles (e.g., "Correctness: 0.5 weight", "Safety: 0.3 weight"), evaluates the trajectory, and extracts behavioral patterns to store as learning memory.
 
 ## Configuration Essentials
 
@@ -115,8 +114,8 @@ rim:
 - Reduce `temperatures` to `[0.3, 0.7]` → Fewer ensemble members
 
 **Different use cases?**
-- **Offline training**: Disable `accuracy` and `diagnostic`, focus on `helpfulness` and `process`
-- **Online evaluation**: Enable all four judges for comprehensive scoring
+- Adjust `variance_threshold` and `uncertainty_threshold` to control escalation frequency
+- Use `focus_prompt` to steer evaluation criteria toward specific domain objectives
 
 ## Reward System in the Atlas SDK
 
@@ -126,31 +125,29 @@ The SDK runtime uses the same reward philosophy to control its execution loop. T
 # configs/examples/openai_agent.yaml
 rim:
   small_model:
-    provider: openai
-    model: gpt-4o-mini
-    api_key_env: OPENAI_API_KEY
-    max_output_tokens: 512
+    provider: google
+    model: gemini/gemini-2.5-flash
+    api_key_env: GEMINI_API_KEY
+    max_output_tokens: 8096
   large_model:
-    provider: openai
-    model: gpt-4o
-    api_key_env: OPENAI_API_KEY
-    max_output_tokens: 768
-  active_judges:
-    process: true
-    helpfulness: true
+    provider: google
+    model: gemini/gemini-2.5-flash
+    api_key_env: GEMINI_API_KEY
+    max_output_tokens: 8096
+  judge_prompt: 'reward the agent for attending the issues mentioned in the task'
   variance_threshold: 0.15
   uncertainty_threshold: 0.3
 ```
 
 During orchestration, this configuration tells the runtime how to behave:
 
-1. After a step is executed, the `Teacher` hands the output to the Reward System.
-2. Enabled judges (`process`, `helpfulness`) sample scores with the **small model**.
-3. If the judge scores disagree (variance > 0.15) or any judge reports high uncertainty (> 0.3), the system escalates to the **large model** to reconcile the decision.
-4. The final score is returned to the orchestrator; scores below `0.6` (the built-in retry threshold) trigger guidance and a retry. Higher scores allow the workflow to continue.
+1. After execution completes, the session trajectory is evaluated using the **small model** at multiple temperatures for diverse perspectives.
+2. If variance across samples exceeds 0.15 or any sample reports uncertainty > 0.3, the system escalates to the **large model** arbiter.
+3. The final reward includes derived principles, score, rationale, and extracted learning patterns (student_learning, teacher_learning).
+4. The reward informs retry decisions and learning memory—patterns are stored for future sessions.
 
 <Tip>
-Want a stricter runtime? Lower `variance_threshold` or disable a judge in `active_judges`. See the [`SDK Configuration Reference`](/sdk/configuration#reward-system-the-rim-block) for complete syntax.
+Want stricter quality control? Lower `variance_threshold` to increase arbiter usage. See the [`SDK Configuration Reference`](/sdk/configuration#reward-system-the-rim-block) for complete syntax.
 </Tip>
 
 This mirrors the training world: the runtime uses rewards to keep the agent on track, while the training process uses the same signals to improve the underlying models.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -28,6 +28,9 @@ ATLAS gives you a single harness that captures value on every turn of the loop:
 - **Data engine** – every run streams structured traces and reward signals into Postgres (`storage` block) and exports JSONL via the SDK CLI (`arc-atlas --database-url ... --output traces.jsonl`). You own the dataset that reflects how your production agent actually behaves.
 - **Training pipeline** – feed those traces straight into the offline stack (`custom_data.runtime_trace_data.get_runtime_trace_dataset`, GRPO trainers) to ship bespoke teachers or policy checkpoints without hand-labeling.
 
+**What ATLAS does and doesn't do with your data:**
+The runtime loop operates purely through feedback—no model weights are modified during production execution. The Student↔Teacher interaction happens via prompts and rewards that steer behavior in real time without touching the underlying models. Weight updates are entirely optional: you choose when to run offline GRPO training jobs on your own infrastructure. Persistent memory (trace storage) can stay disabled for ephemeral sessions, or you can point it at your own Postgres instance—ATLAS never controls or accesses your data stores. You retain complete ownership and control over what gets stored, where it lives, and whether persistence is enabled at all.
+
 Use the runtime for instant lift, then plug the same traces into GRPO when you need custom weights—the data you collect in production is the fuel for both. Online continual learning now lives in the [atlas-sdk](https://github.com/Arc-Computer/atlas-sdk) repository.
 
 ### End-to-End Lifecycle at a Glance

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -39,6 +39,10 @@ Load those variables before you orchestrate runs.
 
 Atlas ships YAML templates for the three adapter families. Copy the closest example from the SDK (`configs/examples/`) and edit the `agent` block. For instance, to wrap a local HTTP service:
 
+<Tip>
+**Understanding Student & Teacher roles:** The config below references `student` and `teacher` blocks. The **Student** is your base agent (the model executing tasks), and the **Teacher** is a reviewer that provides real-time feedback to improve outputs—no model weights are modified. This two-persona architecture enables quality control and adaptive guidance at runtime. See [`Student & Teacher Roles`](/sdk/student-teacher-roles) for the complete mental model.
+</Tip>
+
 ```yaml
 # configs/my_http_agent.yaml
 agent:
@@ -93,6 +97,10 @@ Need persistence? Add a `storage:` block in your YAML (see below) so every sessi
 ## Step 4 — Persist and export traces
 
 Enable storage:
+
+<Note>
+**Data ownership and control:** All session data writes exclusively to the Postgres database *you* provide and control. ATLAS never operates its own data sink or accesses your database—the `database_url` points to your infrastructure (self-hosted, cloud-managed, or local). If you prefer ephemeral sessions, simply omit the `storage` block entirely, and no persistent data will be created. This step is completely optional and governed by your data policies.
+</Note>
 
 ```yaml
 storage:

--- a/docs/reference/faq.mdx
+++ b/docs/reference/faq.mdx
@@ -11,6 +11,18 @@ icon: question
 
 ATLAS (Adaptive Teaching and Learning Alignment System) is a framework that trains "teacher" models to improve "student" model performance through adaptive guidance. It uses a two-pass protocol: diagnostic assessment followed by targeted teaching.
 
+### Does ATLAS train on my production data?
+
+No. The runtime loop operates through inference-time feedback—no model weights are modified during production execution. Weight updates only happen when you explicitly run offline GRPO training jobs on your own infrastructure.
+
+**Data control:**
+- All session traces write exclusively to the Postgres database you provide via `storage.database_url`
+- ATLAS never operates its own data store or accesses your database
+- Leave `storage: null` in your config to run in ephemeral mode with no persistent data
+- Training is opt-in: you choose when to export traces and run offline training
+
+The runtime learns by storing successful guidance patterns in memory (when storage is enabled) and retrieving them for similar future tasks—this is inference-time adaptation, not model training.
+
 ### How is ATLAS different from fine-tuning?
 
 Unlike fine-tuning which modifies model weights, ATLAS:

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -134,26 +134,30 @@ The Reward System scores each attempt so the orchestrator knows whether to accep
 ```yaml
 rim:
   small_model:
-    provider: openai
-    model: gpt-4o-mini
-    api_key_env: OPENAI_API_KEY
+    provider: google
+    model: gemini/gemini-2.5-flash
+    api_key_env: GEMINI_API_KEY
     max_output_tokens: 512
   large_model:
-    provider: openai
-    model: gpt-4o
-    api_key_env: OPENAI_API_KEY
+    provider: google
+    model: gemini/gemini-2.5-flash
+    api_key_env: GEMINI_API_KEY
     max_output_tokens: 768
+  judge_prompt: 'Reward runs that follow the plan, stay safe, and finish the task.'
   active_judges:
     process: true
     helpfulness: true
   variance_threshold: 0.15
   uncertainty_threshold: 0.3
-  parallel_workers: 4
 ```
 
+- **`judge_prompt`**: Steer evaluation criteria toward specific domain objectives. The evaluator includes this prompt when deriving principles and scoring the trajectory.
 - **Judge toggles**: Enable or disable built-in judges through `active_judges`. Custom judges can be added by extending `atlas.evaluation.judges`.
 - **Escalation models**: `small_model` handles the fast path; `large_model` resolves disagreements when variance or uncertainty exceed the configured thresholds.
 - **Retry behaviour**: The orchestrator retries when the aggregated score falls below `0.6` (built-in default). Adjust `max_retries` in the orchestration block to cap how many attempts are made.
+
+**Defining domain-agnostic objectives:**
+The RIM block lets you express generic quality criteria (like security guardrails, compliance checks, or output correctness) in natural language through judge prompts—no model training required. Each judge evaluates a dimension (e.g., "Does this response avoid prompt injection?", "Is the reasoning process sound?") and the system reconciles multiple judge opinions via ensemble and escalation. Importantly, this scoring loop never modifies model weights; it operates purely at inference time to provide feedback signals that steer behavior and inform retry decisions. Think of RIM as an evaluation and governance layer, not a training mechanism. See [`Reward Design`](/concepts/reward-design) for examples of how to define objectives through judge prompts.
 
 Learn more in [`Reward Design`](/concepts/reward-design#reward-system-in-the-atlas-sdk).
 
@@ -188,13 +192,13 @@ adaptive_teaching:
 - **`triage_adapter`**: A dotted path to a Python callable that returns a `TriageDossier`. Use `atlas triage init --domain <code|sre|support>` to scaffold a custom adapter.
 - **`default_tags`**: Labels automatically attached to persona memories and adaptive telemetry.
 - **`probe`**: Configures the capability probe LLM. Adjust the confidence thresholds, fallback behaviour, evidence length, or timeout. Set `probe.llm` if you want to override the default Gemini model.
-- **`reward`**: Override the reward objective. Stick with `rim` for the built-in judges or choose `python` and point `import_path`/`attribute` to your own scorer.
+- **`reward`**: Override the reward objective. Set `type: rim` for the built-in evaluator or `type: python` to point at a custom scorer via `import_path`/`attribute`. Use `focus_prompt` to steer the evaluation toward specific quality criteria—the evaluator includes this prompt when deriving principles and scoring the trajectory.
 
 See the [Adaptive Runtime Guide](/runtime_adaptive_flow) for a walkthrough of how these fields shape triage, probing, and lane decisions.
 
 ## Storage (`storage`)
 
-Optional Postgres persistence for traces and session metadata.
+Postgres persistence for traces and learning memory—**required for continual improvement across runs**.
 
 ```yaml
 storage:
@@ -204,7 +208,11 @@ storage:
   statement_timeout_seconds: 30
 ```
 
-Leave `storage: null` when you don’t have a database. Enable it when you want durable telemetry or plan to export datasets:
+**How storage enables learning:**
+Without storage, each run is isolated—no memory persists between sessions. With storage enabled, ATLAS remembers what guidance worked on past tasks and retrieves those successful patterns for similar future runs. This persistent memory drives token efficiency gains and faster resolution on repeated scenarios. The system learns at inference time by recalling helpful strategies, not by modifying model weights.
+
+**You control where data lives:**
+When enabled, all traces write only to the Postgres database you provide via `database_url`—your self-hosted, cloud-managed, or local instance. ATLAS never operates its own data store or intermediary sink. You retain complete ownership and access control. Leave `storage: null` to run in ephemeral mode (no persistence), but note that this disables cross-session learning. Enable storage when you want continual gains:
 
 ```bash
 arc-atlas \


### PR DESCRIPTION
Updates documentation to match current atlas-sdk implementation.

Changes:
- Clarify runtime feedback vs training
- Update reward system config examples  
- Add data ownership notes
- Update Student/Teacher explanations